### PR TITLE
Updating to latest version of go-oci8 library because of seg-faults

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/beorn7/perks v1.0.0
 	github.com/golang/protobuf v1.3.1
-	github.com/mattn/go-oci8 v0.0.0-20160329132525-7a6ecfe0eedf
+	github.com/mattn/go-oci8 v0.0.8
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90


### PR DESCRIPTION
Hit some segfaults upon freeing memory occasionally while running:

```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x2e94b90 pc=0x7f3c6d83cbb7]

runtime stack:
runtime.throw(0x94d4c2, 0x2a)
        /usr/local/go/src/runtime/panic.go:1116 +0x72
runtime.sigpanic()
        /usr/local/go/src/runtime/signal_unix.go:679 +0x46a

goroutine 4554 [syscall]:
runtime.cgocall(0x842e40, 0xc000155580, 0xc000000000)
        /usr/local/go/src/runtime/cgocall.go:133 +0x5b fp=0xc000155550 sp=0xc000155518 pc=0x40687b
github.com/mattn/go-oci8._Cfunc_OCIHandleFree(0x2e94b90, 0x2, 0x0)
        _cgo_gotypes.go:419 +0x4d fp=0xc000155580 sp=0xc000155550 pc=0x7206ed
github.com/mattn/go-oci8.(*OCI8Conn).Close.func3(0xc00025f500, 0x0)
        /go/pkg/mod/github.com/mattn/go-oci8@v0.0.0-20160329132525-7a6ecfe0eedf/oci8.go:563 +0x5e fp=0xc0001555b8 sp=0xc000155580 pc=0x72915e
<SNIP>
```

The version being used wasn't even a versioned object, so upgrading to the
latest version seems the best place to start.